### PR TITLE
Specified updated war version to prevent installation failure.

### DIFF
--- a/jochre_parent/pom.xml
+++ b/jochre_parent/pom.xml
@@ -262,6 +262,11 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-war-plugin</artifactId>
+        <version>3.3.2</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
         <version>2.6</version>
         <configuration>


### PR DESCRIPTION
See: https://github.com/urieli/jochre/issues/93#issue-1673115239 
The default version of maven-war-plugin was causing an installation error so I specified a version in the pom.xml of jochre_parent. Now it installs smoothly.